### PR TITLE
Allow empty keys as defined in the JSON spec.

### DIFF
--- a/src/JsonReader.php
+++ b/src/JsonReader.php
@@ -447,9 +447,6 @@ class JsonReader implements ChunkJsonReaderInterface
             }
             $objectKey .= $character;
         }
-        if ($objectKey === '') {
-            throw new MalformedJsonException('Object key cannot be empty');
-        }
         $character = $this->characterIterator->getNextNonWhite();
         if ($character != ':') {
             throw new MalformedJsonException('Expected : after object key');


### PR DESCRIPTION
Hi,

the lib currenty disallows empty JSON keys although they are allowed by the JSON spec. I found several other libs with similar issues, where fixes have been suggested and pulled, so I'm quite confident it is correct to allow empty keys.

My use case worked with this fix although I'm not sure if there are other implications (tests do not cover this).